### PR TITLE
feat: implement consumerToken per timely customer

### DIFF
--- a/schemas/timely-customer.ts
+++ b/schemas/timely-customer.ts
@@ -64,6 +64,15 @@ export const timelyCustomer = defineType({
       validation: Rule => Rule.required(),
     },
     {
+      group: 'tripletex',
+      name: 'consumerToken',
+      type: 'string',
+      title: 'Consumer Token',
+      description: `
+        The token used to communicate with the tenant's Tripletex API.
+      `,
+    },
+    {
       name: 'employees',
       type: 'array',
       title: 'Employees',


### PR DESCRIPTION
### TL;DR:

Since each timely customer needs someone with a consumer token, but there's no guarantee a single token has privileges to every project, adding a token per customer seems sensible to me

### What's changed

This is adding a new field called consumerToken under the `tripletex` group. no other changes.

### Why

This is to ensure issues with consumerTokens not having privileges where it is assumed it does. The reason this rule is not set as required is that we can fill the value out when we have the correct key for the relevant users. Then we can make it required later.